### PR TITLE
Adding original error object to the saga error object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "saga-framework",
-  "version": "0.0.1",
+  "name": "node-sagas",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "test": "jest --config ./jest-config.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-    "prepare" : "npm run build",
-    "prepublishOnly" : "npm test && npm run lint",
-    "preversion" : "npm run lint",
-    "version" : "npm run format",
-    "postversion" : "git push && git push --tags"
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test && npm run lint",
+    "preversion": "npm run lint",
+    "version": "npm run format",
+    "postversion": "git push && git push --tags"
   },
   "dependencies": {},
   "devDependencies": {
@@ -38,5 +38,13 @@
     "type": "git",
     "url": "git+https://github.com/SlavaPanevskiy/node-sagas.git"
   },
-  "keywords": ["saga", "sagas", "microservice", "microservices", "distributed transaction", "msa", "microservice-architecture"]
+  "keywords": [
+    "saga",
+    "sagas",
+    "microservice",
+    "microservices",
+    "distributed transaction",
+    "msa",
+    "microservice-architecture"
+  ]
 }

--- a/src/exceptions/saga-compensation-failed.ts
+++ b/src/exceptions/saga-compensation-failed.ts
@@ -1,6 +1,9 @@
 export class SagaCompensationFailed extends Error {
+  originalError: Error;
+
   constructor(e: Error) {
     super(e.message);
     this.stack = e.stack;
+    this.originalError = e;
   }
 }

--- a/src/exceptions/saga-exuction-failed.ts
+++ b/src/exceptions/saga-exuction-failed.ts
@@ -1,6 +1,9 @@
 export class SagaExecutionFailed extends Error {
+  originalError: Error;
+
   constructor(e: Error) {
     super(e.message);
     this.stack = e.stack;
+    this.originalError = e;
   }
 }


### PR DESCRIPTION
Some custom errors have custom useful properties to provide more information about the error.

## Current behavior

The current behavior of both `SagaExecutionFailed` and `SagaCompensationFailed` error objects only shows you the message of the original error which sometimes makes it harder for error handling.

## Example

For example, `mysql` package provides `code`, `errno`, `sqlMessage`, `sqlState`, `index`, and `sql` properties in their error object which are useful. They also provide constants of `errno` which can be used to check against any error. If there is any `mysql` error in a saga, I can see only the message of the `mysql` error.

## Solution

In this pull request, I've added the `originalError` properties to both `SagaExecutionFailed` and `SagaCompensationFailed` classes so that I can get more information about the original error.

By the way, thanks for this great package! 👍 